### PR TITLE
Upgrade gitlab client to fix error on latest ruby version

### DIFF
--- a/gitlab-release-tools.gemspec
+++ b/gitlab-release-tools.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   #spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "gitlab", "~> 4.12.0"
+  spec.add_runtime_dependency "gitlab", "~> 4.17.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/gitlab/release/version.rb
+++ b/lib/gitlab/release/version.rb
@@ -1,5 +1,5 @@
 module Gitlab
   module Release
-    VERSION = "1.0.1"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
The version of gitlab ruby client is out of date and not working on latest ruby version